### PR TITLE
Support Flutter 1.12.13

### DIFF
--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -59,9 +59,6 @@ public class OpenFilePlugin implements MethodCallHandler
     private static final int RESULT_CODE = 0x12;
     private static final String TYPE_STRING_APK = "application/vnd.android.package-archive";
 
-    private OpenFilePlugin() {
-    }
-
     public static void registerWith(Registrar registrar) {
         OpenFilePlugin plugin = new OpenFilePlugin();
         plugin.activity = registrar.activity();


### PR DESCRIPTION
OpenFilePlugin must be public because the GeneratedPluginRegistrant.java file will new the instance.