### PR TITLE
Fixed a typo in the error message for fileNotFound

### DIFF
--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -131,7 +131,7 @@ public class OpenFilePlugin implements MethodCallHandler
     private void startActivity() {
         File file = new File(filePath);
         if (!file.exists()) {
-            result(-2, "the " + filePath + " file is not exists");
+            result(-2, "the " + filePath + " file does not exists");
             return;
         }
 

--- a/ios/Classes/OpenFilePlugin.m
+++ b/ios/Classes/OpenFilePlugin.m
@@ -118,7 +118,7 @@ static NSString *const CHANNEL_NAME = @"open_file";
                 result(json);
             }
         }else{
-            NSDictionary * dict = @{@"message":@"the file is not exist", @"type":@-2};
+            NSDictionary * dict = @{@"message":@"the file does not exist", @"type":@-2};
             NSData * jsonData = [NSJSONSerialization dataWithJSONObject:dict options:NSJSONWritingPrettyPrinted error:nil];
             NSString * json = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 


### PR DESCRIPTION
Fixed a typo in the message returned with the `fileNotFound` error.