### PR TITLE
fix multiple file providers

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 
     <application>
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name="com.crazecoder.openfile.FileProvider"
             android:authorities="${applicationId}.fileProvider"
             android:exported="false"
             android:grantUriPermissions="true"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <application>
         <provider
             android:name="com.crazecoder.openfile.FileProvider"
-            android:authorities="${applicationId}.fileProvider"
+            android:authorities="${applicationId}.fileProvider.com.crazecoder.openfile"
             android:exported="false"
             android:grantUriPermissions="true"
             tools:replace="android:authorities">

--- a/android/src/main/java/com/crazecoder/openfile/FileProvider.java
+++ b/android/src/main/java/com/crazecoder/openfile/FileProvider.java
@@ -1,0 +1,4 @@
+package com.crazecoder.openfile;
+
+public class FileProvider extends androidx.core.content.FileProvider {
+}

--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -141,7 +141,7 @@ public class OpenFilePlugin implements MethodCallHandler
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             String packageName = context.getPackageName();
-            Uri uri = FileProvider.getUriForFile(context, packageName + ".fileProvider", new File(filePath));
+            Uri uri = FileProvider.getUriForFile(context, packageName + ".fileProvider.com.crazecoder.openfile", new File(filePath));
             intent.setDataAndType(uri, typeString);
         } else {
             intent.setDataAndType(Uri.fromFile(file), typeString);


### PR DESCRIPTION
Conflict with flutter_webview_plugin file providers

plugin use private providers
eg:
image_picker: ^0.6.7+4
```
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
  package="io.flutter.plugins.imagepicker">
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

    <application>
        <provider
            android:name="io.flutter.plugins.imagepicker.ImagePickerFileProvider"
            android:authorities="${applicationId}.flutter.image_provider"
            android:exported="false"
            android:grantUriPermissions="true">
            <meta-data
                android:name="android.support.FILE_PROVIDER_PATHS"
                android:resource="@xml/flutter_image_picker_file_paths"/>
        </provider>
    </application>
</manifest>`
```

install_apk_plugin: ^1.0.1

```
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
  package="com.example.installplugin">
    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
    <application>
        <provider
            android:name="com.zaihui.installplugin.FileProvider"
            android:authorities="${applicationId}.fileProvider.install"
            android:exported="false"
            android:grantUriPermissions="true">
            <meta-data
                android:name="android.support.FILE_PROVIDER_PATHS"
                android:resource="@xml/provider_install_paths"/>
        </provider>
    </application>
</manifest>

```

