### PR TITLE
Changed OpenFile constructor to private

### DIFF
--- a/lib/src/plaform/open_file.dart
+++ b/lib/src/plaform/open_file.dart
@@ -10,6 +10,8 @@ import 'windows.dart' as windows;
 
 class OpenFile {
   static const MethodChannel _channel = const MethodChannel('open_file');
+  
+  OpenFile._();
 
   ///linuxDesktopName like 'xdg'/'gnome'
   static Future<OpenResult> open(String filePath,


### PR DESCRIPTION
Since there is no need to create an instance of OpenFile, I think it's better to make it's constructor private.