### PR TITLE
Upgrade to FFI 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.1.0
+* Support FFI 1.0.0
 ## 3.0.3
 * upgrade compileSdkVersion
 ## 3.0.2

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,10 @@ description: Demonstrates how to use the open_file plugin.
 # Read more about versioning at semver.org.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.9.0 <3.0.0"
+  flutter: ">=1.12.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/lib/src/plaform/linux.dart
+++ b/lib/src/plaform/linux.dart
@@ -14,7 +14,7 @@ int system(String command) {
   final systemP = dylib.lookupFunction<SystemC, SystemDart>('system');
 
   // Allocate a pointer to a Utf8 array containing our command.
-  final cmdP = Utf8.toUtf8(command);
+  final cmdP = command.toNativeUtf8();
 
   // Invoke the command, and free the pointer.
   int result = systemP(cmdP);

--- a/lib/src/plaform/macos.dart
+++ b/lib/src/plaform/macos.dart
@@ -14,7 +14,7 @@ int system(String command) {
   final systemP = dylib.lookupFunction<SystemC, SystemDart>('system');
 
   // Allocate a pointer to a Utf8 array containing our command.
-  final cmdP = Utf8.toUtf8(command);
+  final cmdP = command.toNativeUtf8();
 
   // Invoke the command, and free the pointer.
   int result = systemP(cmdP);

--- a/lib/src/plaform/windows.dart
+++ b/lib/src/plaform/windows.dart
@@ -25,8 +25,8 @@ int shellExecute(String operation, String file) {
       dylib.lookupFunction<ShellExecuteC, ShellExecuteDart>('ShellExecuteW');
 
   // Allocate pointers to Utf8 arrays containing the command arguments.
-  final operationP = Utf16.toUtf16(operation);
-  final fileP = Utf16.toUtf16(file);
+  final operationP = operation.toNativeUtf16();
+  final fileP = file.toNativeUtf16();
   const int SW_SHOWNORMAL = 1;
 
   // Invoke the command, and free the pointers.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,15 +4,15 @@ version: 3.0.3
 author: crazecoder <21527312@qq.com>
 homepage: https://github.com/crazecoder/open_file
 
+environment:
+  sdk: ">=2.9.0 <3.0.0"
+  flutter: ">=1.12.0"
 
 dependencies:
   flutter:
     sdk: flutter
   ffi: ^0.1.3
 
-environment:
-    sdk: ">=2.1.0 <3.0.0"
-    flutter: ">=1.12.0 <2.0.0"
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_file
 description: A plug-in that can call native APP to open files with string result in flutter, support iOS(UTI) / android(intent) / PC(ffi) / web(dart:html)
-version: 3.0.3
+version: 3.1.0
 author: crazecoder <21527312@qq.com>
 homepage: https://github.com/crazecoder/open_file
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ffi: ^0.1.3
+  ffi: ^1.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Two changes:

  1. Fix formatting in pubspecs to correctly encode SDK constraints
  1. Upgrade to `package:ffi` version 1.0.0

@dcharkes, can you please review?