### PR TITLE
Migrate to Dart null safety system

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,32 +3,30 @@ import 'dart:async';
 
 import 'package:open_file/open_file.dart';
 
-void main() => runApp(new MyApp());
+void main() => runApp(MyApp());
 
 class MyApp extends StatefulWidget {
   @override
-  _MyAppState createState() => new _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
-  String _openResult = 'Unknown';
+  var _openResult = 'Unknown';
 
   Future<void> openFile() async {
-
     final filePath = '/storage/emulated/0/update.apk';
     final result = await OpenFile.open(filePath);
 
     setState(() {
       _openResult = "type=${result.type}  message=${result.message}";
     });
-
   }
 
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
-      home: new Scaffold(
-        appBar: new AppBar(
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
           title: const Text('Plugin example app'),
         ),
         body: Center(
@@ -36,7 +34,7 @@ class _MyAppState extends State<MyApp> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               Text('open result: $_openResult\n'),
-              FlatButton(
+              TextButton(
                 child: Text('Tap to open file'),
                 onPressed: openFile,
               ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,9 @@ description: Demonstrates how to use the open_file plugin.
 # Read more about versioning at semver.org.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.1.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/lib/src/common/open_result.dart
+++ b/lib/src/common/open_result.dart
@@ -8,7 +8,7 @@ class OpenResult {
       : message = json['message'],
         type = _convertJson(json['type']);
 
-  static ResultType _convertJson(int jsonType) {
+  static ResultType _convertJson(int? jsonType) {
     switch (jsonType) {
       case -1:
         return ResultType.noAppToOpen;

--- a/lib/src/plaform/linux.dart
+++ b/lib/src/plaform/linux.dart
@@ -14,11 +14,11 @@ int system(String command) {
   final systemP = dylib.lookupFunction<SystemC, SystemDart>('system');
 
   // Allocate a pointer to a Utf8 array containing our command.
-  final cmdP = Utf8.toUtf8(command);
+  final cmdP = command.toNativeUtf8();
 
   // Invoke the command, and free the pointer.
-  int result = systemP(cmdP);
-//  cmdP.free();
+  final result = systemP(cmdP);
+  calloc.free(cmdP);
 
   return result;
 }

--- a/lib/src/plaform/macos.dart
+++ b/lib/src/plaform/macos.dart
@@ -14,11 +14,11 @@ int system(String command) {
   final systemP = dylib.lookupFunction<SystemC, SystemDart>('system');
 
   // Allocate a pointer to a Utf8 array containing our command.
-  final cmdP = Utf8.toUtf8(command);
+  final cmdP = command.toNativeUtf8();
 
   // Invoke the command, and free the pointer.
-  int result = systemP(cmdP);
-//  cmdP.free();
+  final result = systemP(cmdP);
+  calloc.free(cmdP);
 
   return result;
 }

--- a/lib/src/plaform/open_file.dart
+++ b/lib/src/plaform/open_file.dart
@@ -10,12 +10,12 @@ import 'windows.dart' as windows;
 
 class OpenFile {
   static const MethodChannel _channel = const MethodChannel('open_file');
-  
+
   OpenFile._();
 
   ///linuxDesktopName like 'xdg'/'gnome'
   static Future<OpenResult> open(String filePath,
-      {String type, String uti, String linuxDesktopName = "xdg"}) async {
+      {String? type, String? uti, String linuxDesktopName = "xdg"}) async {
     if (!Platform.isIOS && !Platform.isAndroid) {
       int _result;
       if (Platform.isMacOS) {
@@ -32,9 +32,13 @@ class OpenFile {
               : "there are some errors when open $filePath");
     }
 
-    Map<String, String> map = {"file_path": filePath, "type": type, "uti": uti};
+    Map<String, String?> map = {
+      "file_path": filePath,
+      "type": type,
+      "uti": uti,
+    };
     final _result = await _channel.invokeMethod('open_file', map);
-    Map resultMap = json.decode(_result);
+    final resultMap = json.decode(_result) as Map<String, dynamic>;
     return OpenResult.fromJson(resultMap);
   }
 }

--- a/lib/src/plaform/windows.dart
+++ b/lib/src/plaform/windows.dart
@@ -25,15 +25,15 @@ int shellExecute(String operation, String file) {
       dylib.lookupFunction<ShellExecuteC, ShellExecuteDart>('ShellExecuteW');
 
   // Allocate pointers to Utf8 arrays containing the command arguments.
-  final operationP = Utf16.toUtf16(operation);
-  final fileP = Utf16.toUtf16(file);
+  final operationP = operation.toNativeUtf16();
+  final fileP = file.toNativeUtf16();
   const int SW_SHOWNORMAL = 1;
 
   // Invoke the command, and free the pointers.
-  var result = shellExecuteP(
+  final result = shellExecuteP(
       ffi.nullptr, operationP, fileP, ffi.nullptr, ffi.nullptr, SW_SHOWNORMAL);
-//  operationP.free();
-//  fileP.free();
+  calloc.free(operationP);
+  calloc.free(fileP);
 
   return result;
 }

--- a/lib/src/web/open_file.dart
+++ b/lib/src/web/open_file.dart
@@ -5,8 +5,8 @@ import 'web.dart' as web;
 
 class OpenFile {
   static Future<OpenResult> open(String filePath,
-      {String type, String uti, String linuxDesktopName = "xdg"}) async {
-    bool _b = await web.open("file://$filePath");
+      {String? type, String? uti, String linuxDesktopName = "xdg"}) async {
+    final _b = await web.open("file://$filePath");
     return OpenResult(
         type: _b ? ResultType.done : ResultType.error,
         message: _b ? "done" : "there are some errors when open $filePath");

--- a/lib/src/web/web.dart
+++ b/lib/src/web/web.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
+
+// ignore: avoid_web_libraries_in_flutter
 import 'dart:html';
 
 Future<bool> open(String uri) async {
-  try {
-    Entry _e = await window.resolveLocalFileSystemUrl(uri);
-    return _e != null;
-  } catch (e) {
-    print(e);
-    return false;
-  }
+  return window
+      .resolveLocalFileSystemUrl(uri)
+      .then((_) => true)
+      .catchError((e) => false);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ homepage: https://github.com/crazecoder/open_file
 dependencies:
   flutter:
     sdk: flutter
-  ffi: ^0.1.3
+  ffi: ^1.0.0
 
 environment:
-    sdk: ">=2.1.0 <3.0.0"
-    flutter: ">=1.12.0 <2.0.0"
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: ">=1.12.0 <2.0.0"
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 


### PR DESCRIPTION
Hi,

I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:

* Update SDK dependency version to 2.12.0+
* Update `ffi` dependency to the new null-safe version (1.0.0)
* Run `dart migrate` on existing code to remove unsafe nulls, there is not so many changes to the codebase as your code was already pretty much null-safe, thank you for that 😄  🎉 
* Format some code

Thank you for the great work on this plugin and let me know if I can rework something !

Notes:

* This PR closes #130 
* This PR also updates deprecated codes after ffi lib update just as PR #134 did.

cc @crazecoder