### PR TITLE
Fix startActivity() might have NPE issue with filePath

### DIFF
--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -129,6 +129,9 @@ public class OpenFilePlugin implements MethodCallHandler
 
 
     private void startActivity() {
+        if (filePath == null) {
+            return;
+        }
         File file = new File(filePath);
         if (!file.exists()) {
             result(-2, "the " + filePath + " file does not exists");


### PR DESCRIPTION
Some systems force app to restart after the install unknown packages permission is granted/changed. At that time, the whole activity will be destroyed, which makes the `filePath` itself became when calling. By simply adding a null check can avoid the crash.

> 某些系统会在更改安装未知应用权限时，强制 App 重新启动，此时整个 Activity 都会被销毁，导致传递的方法中 `filePath` 为空。仅需要加入一个空判断，即可让应用正常重新唤醒，而不会直接闪退。