### PR TITLE
Add command parser before create system call #144

### DIFF
--- a/lib/src/plaform/linux.dart
+++ b/lib/src/plaform/linux.dart
@@ -1,20 +1,21 @@
 import 'dart:ffi' as ffi;
 
 import 'package:ffi/ffi.dart';
+import 'package:open_file/src/plaform/parse_args.dart';
 
 typedef SystemC = ffi.Int32 Function(ffi.Pointer<Utf8> command);
 
 typedef SystemDart = int Function(ffi.Pointer<Utf8> command);
 
-int system(String command) {
-  // Load `stdlib`. On MacOS this is in libSystem.dylib.
+int system(List<String> command) {
+  // Load `stdlib`. On Linux this is in libc.so.6.
   final dylib = ffi.DynamicLibrary.open('libc.so.6');
 
   // Look up the `system` function.
   final systemP = dylib.lookupFunction<SystemC, SystemDart>('system');
 
   // Allocate a pointer to a Utf8 array containing our command.
-  final cmdP = command.toNativeUtf8();
+  final cmdP = parseArgs(command).toNativeUtf8();
 
   // Invoke the command, and free the pointer.
   final result = systemP(cmdP);

--- a/lib/src/plaform/macos.dart
+++ b/lib/src/plaform/macos.dart
@@ -1,12 +1,13 @@
 import 'dart:ffi' as ffi;
 
 import 'package:ffi/ffi.dart';
+import 'package:open_file/src/plaform/parse_args.dart';
 
 typedef SystemC = ffi.Int32 Function(ffi.Pointer<Utf8> command);
 
 typedef SystemDart = int Function(ffi.Pointer<Utf8> command);
 
-int system(String command) {
+int system(List<String> args) {
   // Load `stdlib`. On MacOS this is in libSystem.dylib.
   final dylib = ffi.DynamicLibrary.open('/usr/lib/libSystem.dylib');
 
@@ -14,7 +15,7 @@ int system(String command) {
   final systemP = dylib.lookupFunction<SystemC, SystemDart>('system');
 
   // Allocate a pointer to a Utf8 array containing our command.
-  final cmdP = command.toNativeUtf8();
+  final cmdP = parseArgs(args).toNativeUtf8();
 
   // Invoke the command, and free the pointer.
   final result = systemP(cmdP);

--- a/lib/src/plaform/open_file.dart
+++ b/lib/src/plaform/open_file.dart
@@ -23,12 +23,12 @@ class OpenFile {
       int _result;
       var _windowsResult;
       if (Platform.isMacOS) {
-        _result = mac.system('open $filePath');
+        _result = mac.system(['open', '$filePath']);
       } else if (Platform.isLinux) {
         if (linuxByProcess) {
           _result = Process.runSync('xdg-open', [filePath]).exitCode;
         } else {
-          _result = linux.system('$linuxDesktopName-open "$filePath"');
+          _result = linux.system(['$linuxDesktopName-open', '$filePath']);
         }
       } else if (Platform.isWindows) {
         _windowsResult = windows.shellExecute('open', filePath);

--- a/lib/src/plaform/parse_args.dart
+++ b/lib/src/plaform/parse_args.dart
@@ -1,0 +1,4 @@
+String parseArgs(List<String> args) {
+  final commandList = args.map((arg) => arg.replaceAll(' ', '\\ ')).toList();
+  return commandList.join(' ');
+}


### PR DESCRIPTION
May I suggest to create a command parser aware of spaces to avoid errors when filenames containing spaces would not open on mac. As well of being able to concatenate multiple commands if needed in the future.

- Change mac implementation to use the parser

- Also changed in linux which would have the same effect.

- And changed system calls to receive a list of args to keep it open to extension in the future.

- A minor fix on the comment of the linux implementation.