### PR TITLE
Fix for null plugin binding error.

### DIFF
--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -425,6 +425,11 @@ public class OpenFilePlugin implements MethodCallHandler
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
         this.flutterPluginBinding = binding;
+        channel =
+                new MethodChannel(
+                        flutterPluginBinding.getBinaryMessenger(), "open_file");
+        context = flutterPluginBinding.getApplicationContext();
+        channel.setMethodCallHandler(this);
     }
 
     @Override
@@ -441,12 +446,7 @@ public class OpenFilePlugin implements MethodCallHandler
 
     @Override
     public void onAttachedToActivity(ActivityPluginBinding binding) {
-        channel =
-                new MethodChannel(
-                        flutterPluginBinding.getBinaryMessenger(), "open_file");
-        context = flutterPluginBinding.getApplicationContext();
         activity = binding.getActivity();
-        channel.setMethodCallHandler(this);
         binding.addRequestPermissionsResultListener(this);
         binding.addActivityResultListener(this);
     }


### PR DESCRIPTION
Fixes problems in an Add-to-App scenario when FlutterActivity will be opened, then closed and re-opened again.
This causes an exception in onAttachedToActivity during plugin initialization.
The problem is creating the MethodChannel here is the wrong place as the global variable flutterPluginBinding is still null (the order of calling onAttachToEngine and onAttachedToActivity seams to change after launching FlutterActivity a second time).

original issue: #163