### PR TITLE
fail to pop up When Use Flutter_boost

### DIFF
--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -151,9 +151,19 @@ public class OpenFilePlugin implements MethodCallHandler
         }
 
         try {
-            String appDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
+//            String appDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
+//            String fileCanonicalPath = new File(filePath).getCanonicalPath();
+//            return !fileCanonicalPath.startsWith(appDirCanonicalPath);
+            String appDirFilePath = context.getExternalFilesDir(null).getCanonicalPath();
+            String appDirCachePath = context.getExternalCacheDir().getCanonicalPath();
             String fileCanonicalPath = new File(filePath).getCanonicalPath();
-            return !fileCanonicalPath.startsWith(appDirCanonicalPath);
+            if (fileCanonicalPath.startsWith(appDirFilePath)) {
+                return false;
+            } else if (fileCanonicalPath.startsWith(appDirCachePath)) {
+                return false;
+            } else {
+                return true;
+            }
         } catch (IOException e) {
             e.printStackTrace();
             return true;

--- a/ios/Classes/OpenFilePlugin.m
+++ b/ios/Classes/OpenFilePlugin.m
@@ -117,7 +117,7 @@ static NSString *const CHANNEL_NAME = @"open_file";
             @try {
                 BOOL previewSucceeded = [_documentController presentPreviewAnimated:YES];
                 if(!previewSucceeded){
-                    [_documentController presentOpenInMenuFromRect:CGRectMake(500,20,100,100) inView:_viewController.view animated:YES];
+                    [_documentController presentOpenInMenuFromRect:CGRectMake(500,20,100,100) inView:[UIApplication sharedApplication].delegate.window.rootViewController.view animated:YES];
                 }
             }@catch (NSException *exception) {
                 NSDictionary * dict = @{@"message":@"File opened incorrectly。", @"type":@-4};
@@ -154,7 +154,7 @@ static NSString *const CHANNEL_NAME = @"open_file";
 }
 
 - (UIViewController *)documentInteractionControllerViewControllerForPreview:(UIDocumentInteractionController *)controller {
-    return  _viewController;
+    return [UIApplication sharedApplication].delegate.window.rootViewController;
 }
 
 - (BOOL) isBlankString:(NSString *)string {


### PR DESCRIPTION
With Flutter_boost, when registering the plug-in, [UIApplication sharedApplication].delegate. delegate.windows may also be  modified by function："- (BOOL)application:(UIApplication *)application DidFinishLaunchingWithOptions: (NSDictionary *) launchOptions"， The obtained rootViewController may not be the actual ViewController, when register this plug-in，which will cause the preview screen to fail to pop up