### PR TITLE
Do not throw error if can MANAGE_EXTERNAL_STORAGE

### DIFF
--- a/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
+++ b/android/src/main/java/com/crazecoder/openfile/OpenFilePlugin.java
@@ -78,15 +78,15 @@ public class OpenFilePlugin implements MethodCallHandler
             if (pathRequiresPermission()) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isExternalStoragePublicMedia(mimeType)) {
-                        if (isImage(mimeType) && !hasPermission(Manifest.permission.READ_MEDIA_IMAGES)) {
+                        if (isImage(mimeType) && !hasPermission(Manifest.permission.READ_MEDIA_IMAGES) && !Environment.isExternalStorageManager()) {
                             result(-3, "Permission denied: " + Manifest.permission.READ_MEDIA_IMAGES);
                             return;
                         }
-                        if (isVideo(mimeType) && !hasPermission(Manifest.permission.READ_MEDIA_VIDEO)) {
+                        if (isVideo(mimeType) && !hasPermission(Manifest.permission.READ_MEDIA_VIDEO) && !Environment.isExternalStorageManager()) {
                             result(-3, "Permission denied: " + Manifest.permission.READ_MEDIA_VIDEO);
                             return;
                         }
-                        if (isAudio(mimeType) && !hasPermission(Manifest.permission.READ_MEDIA_AUDIO)) {
+                        if (isAudio(mimeType) && !hasPermission(Manifest.permission.READ_MEDIA_AUDIO) && !Environment.isExternalStorageManager()) {
                             result(-3, "Permission denied: " + Manifest.permission.READ_MEDIA_AUDIO);
                             return;
                         }


### PR DESCRIPTION
On Android, you do not have to have the `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` or `READ_MEDIA_AUDIO` permissions if you have the `MANAGE_EXTERNAL_STORAGE` permission.