### PR TITLE
fix: add namespace (AGP8)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.crazecoder.openfile'
+    }
     compileSdkVersion 33
 
     defaultConfig {


### PR DESCRIPTION
AGP8 requires build.gradle to add namespace.