### PR TITLE
Remove platforms to avoid build errors

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,14 +23,6 @@ flutter:
         pluginClass: OpenFilePlugin
       ios:
         pluginClass: OpenFilePlugin
-      windows:
-        default_package: open_file
-      linux:
-        default_package: open_file
-      macos:
-         pluginClass: OpenFilePlugin
-      web:
-        default_package: open_file
   # To add assets to your plugin package, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg


### PR DESCRIPTION
Build error: Package open_file:linux references open_file:linux as the default plugin, but it does not provide an inline implementation.


Warning when running `flutter pub get`: Package open_file:linux references open_file:linux as the default plugin, but it does not provide an inline implementation. Ask the maintainers of open_file to either avoid referencing a default implementation via `platforms: linux: default_package: open_file` or add an inline implementation to open_file via `platforms: linux:` `pluginClass` or `dartPluginClass`.