### PR TITLE
Update build.gradle add name space for new gradle version

### DIFF
--- a/open_file_android/android/build.gradle
+++ b/open_file_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-
+    namespace 'com.crazecoder.openfile'
     // conditional for compatibility with older gradle versions
     if (project.android.hasProperty('namespace')) {
         namespace "com.crazecoder.openfile"


### PR DESCRIPTION
this change to solve this error A problem occurred configuring project ':open_file'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.
     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.