### PR TITLE
Add namespace for android build.

### DIFF
--- a/open_file/pubspec.yaml
+++ b/open_file/pubspec.yaml
@@ -12,7 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  open_file_android: ^1.0.6
+  open_file_android:
+    version: ^1.0.6
+    path: ../open_file_android
   open_file_web: ^0.0.4
   open_file_ios: ^1.0.3
   open_file_mac: ^1.0.2

--- a/open_file_android/android/build.gradle
+++ b/open_file_android/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "com.crazecoder.openfile"
 
     // conditional for compatibility with older gradle versions
     if (project.android.hasProperty('namespace')) {


### PR DESCRIPTION
Just need to revert the `path` dependency in the main `open_file` package after publishing the android package.