### PR TITLE
ios: add UISceneDelegate support for  iOS 26+

### DIFF
--- a/open_file/pubspec.yaml
+++ b/open_file/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   open_file_android: ^1.0.6
   open_file_web: ^0.0.4
-  open_file_ios: ^1.0.4
+  open_file_ios: ^1.0.5
   open_file_mac: ^1.0.4
   open_file_windows: ^0.0.3
   open_file_linux: ^0.0.5

--- a/open_file_ios/CHANGELOG.md
+++ b/open_file_ios/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.5
+* Add UISceneDelegate support for compatibility with Flutter 3.38+ and iOS 26+.
+  Uses `FlutterPluginRegistrar.viewController` to obtain the root view controller,
+  eliminating reliance on deprecated `UIApplication.windows` enumeration.
+  Falls back to `UIWindowScene.keyWindow` (iOS 15+) or window iteration (iOS 13–14).
+
 ## 1.0.4
 * Fix compatibility with UIScene.
 ## 1.0.3

--- a/open_file_ios/ios/open_file_ios/Sources/open_file_ios/OpenFilePlugin.m
+++ b/open_file_ios/ios/open_file_ios/Sources/open_file_ios/OpenFilePlugin.m
@@ -5,37 +5,70 @@
 
 static NSString *const CHANNEL_NAME = @"open_file";
 
-static UIViewController *RootViewController(void) {
-  if (@available(iOS 13, *)) { // UIApplication.keyWindow is deprecated
-    NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
-    for (UIScene *scene in scenes) {
-      if ([scene isKindOfClass:[UIWindowScene class]]) {
-        NSArray *windows = ((UIWindowScene *)scene).windows;
-        for (UIWindow *window in windows) {
-          if (window.isKeyWindow) {
-            return window.rootViewController;
-          }
-        }
-      }
-    }
-    return nil;
-  } else {
-      return [UIApplication sharedApplication].delegate.window.rootViewController;
-  }
-}
+// Extends FlutterPluginRegistrar to expose viewController available on the
+// concrete FlutterViewControllerRegistrar class used at runtime.
+@protocol OpenFileFlutterPluginRegistrar <FlutterPluginRegistrar>
+@property(nonatomic, readonly, weak) UIViewController *viewController;
+@end
 
 @implementation OpenFilePlugin{
     FlutterResult _result;
     UIDocumentInteractionController *_documentController;
     UIDocumentInteractionController *_interactionController;
+    NSObject<OpenFileFlutterPluginRegistrar> *_registrar;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
     FlutterMethodChannel* channel = [FlutterMethodChannel
                                      methodChannelWithName:CHANNEL_NAME
                                      binaryMessenger:[registrar messenger]];
-    OpenFilePlugin* instance = [[OpenFilePlugin alloc] init];
+    OpenFilePlugin* instance = [[OpenFilePlugin alloc] initWithRegistrar:registrar];
     [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    self = [super init];
+    if (self) {
+        _registrar = (NSObject<OpenFileFlutterPluginRegistrar> *)registrar;
+    }
+    return self;
+}
+
+// Returns the root view controller using the registrar's viewController for
+// UISceneDelegate compatibility (required for Flutter 3.38+ / iOS 26+).
+// Falls back to scene enumeration for environments where the registrar does
+// not expose viewController.
+- (UIViewController *)rootViewController {
+    if ([_registrar respondsToSelector:@selector(viewController)]) {
+        UIViewController *vc = _registrar.viewController;
+        if (vc != nil) {
+            return vc;
+        }
+    }
+    if (@available(iOS 15, *)) {
+        for (UIScene *scene in [[UIApplication sharedApplication] connectedScenes]) {
+            if ([scene isKindOfClass:[UIWindowScene class]]) {
+                UIWindow *keyWindow = ((UIWindowScene *)scene).keyWindow;
+                if (keyWindow != nil) {
+                    return keyWindow.rootViewController;
+                }
+            }
+        }
+        return nil;
+    } else if (@available(iOS 13, *)) {
+        for (UIScene *scene in [[UIApplication sharedApplication] connectedScenes]) {
+            if ([scene isKindOfClass:[UIWindowScene class]]) {
+                for (UIWindow *window in ((UIWindowScene *)scene).windows) {
+                    if (window.isKeyWindow) {
+                        return window.rootViewController;
+                    }
+                }
+            }
+        }
+        return nil;
+    } else {
+        return [UIApplication sharedApplication].delegate.window.rootViewController;
+    }
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -57,7 +90,7 @@ static UIViewController *RootViewController(void) {
             _documentController.delegate = self;
             BOOL isAppOpen = [call.arguments[@"isIOSAppOpen"] boolValue];
             @try {
-                UIViewController *rootViewController = RootViewController();
+                UIViewController *rootViewController = [self rootViewController];
                 if (!rootViewController) {
                     NSDictionary * dict = @{@"message":@"the root view controller could not be found", @"type":@-4};
                     NSData * jsonData = [NSJSONSerialization dataWithJSONObject:dict options:NSJSONWritingPrettyPrinted error:nil];
@@ -110,7 +143,7 @@ static UIViewController *RootViewController(void) {
 }
 
 - (UIViewController *)documentInteractionControllerViewControllerForPreview:(UIDocumentInteractionController *)controller {
-    return RootViewController();
+    return [self rootViewController];
 }
 
 - (BOOL) isBlankString:(NSString *)string {

--- a/open_file_ios/pubspec.yaml
+++ b/open_file_ios/pubspec.yaml
@@ -1,7 +1,7 @@
 name: open_file_ios
 description: iOS implementation of the open_file plugin.
 repository: https://github.com/crazecoder/open_file/tree/master/open_file_ios
-version: 1.0.4
+version: 1.0.5
 
 environment:
   sdk: ">=2.17.0 <4.0.0"


### PR DESCRIPTION
## Summary

- Replaces the static `RootViewController()` function with an instance method that uses `FlutterPluginRegistrar.viewController` to look up the root view controller
- This ties view controller lookup to the actual Flutter scene, which is the approach recommended in the Flutter UISceneDelegate breaking-change migration guide (https://docs.flutter.dev/release/breaking-changes/uiscenedelegate)
- Falls back to `UIWindowScene.keyWindow` (iOS 15+), window iteration (iOS 13-14), or `UIApplication.delegate.window` (iOS <13) when the registrar does not expose `viewController`

## Motivation

Apple now requires iOS apps to adopt the UIScene lifecycle. After iOS 26, apps built with the latest SDK must use UISceneDelegate or they won't launch. Flutter 3.38+ uses UISceneDelegate by default. Without this fix, `UIDocumentInteractionController` and `UIActivityViewController` may fail to find the correct view controller to present from.

## Test plan

- [x] Confirmed working on a Flutter app configured with UISceneDelegate (Flutter 3.38+)
- [x] File preview via `UIDocumentInteractionController` presents correctly
- [x] Open with via `UIActivityViewController` presents correctly

## Related issues
* #353

